### PR TITLE
Bug #99643 Fix broken filename

### DIFF
--- a/library/src/main/java/com/klinker/android/send_message/Transaction.java
+++ b/library/src/main/java/com/klinker/android/send_message/Transaction.java
@@ -470,11 +470,16 @@ public class Transaction {
                         if (part.MimeType.startsWith("text")) {
                             partPdu.setCharset(CharacterSets.UTF_8);
                         }
-
+                        // Set Content-Location.
+                        partPdu.setContentLocation(part.Name.getBytes());
+                        int index = part.Name.lastIndexOf(".");
+                        String contentId = (index == -1) ? part.Name
+                                : part.Name.substring(0, index);
+                        partPdu.setContentId(contentId.getBytes());
                         partPdu.setData(part.Data);
 
                         pduBody.addPart(partPdu);
-                        size += (part.Name.getBytes().length + part.MimeType.getBytes().length + part.Data.length);
+                        size += ((2 * part.Name.getBytes().length) + part.MimeType.getBytes().length + part.Data.length + contentId.getBytes().length);
                     } catch (Exception e) {
                     }
                 }
@@ -664,7 +669,7 @@ public class Transaction {
     }
 
     private static int addTextPart(PduBody pb, MMSPart p, int id) {
-        String filename = p.MimeType.split("/")[0] + "_" + id + ".mms";
+        String filename = p.Name;
         final PduPart part = new PduPart();
         // Set Charset if it's a text media.
         if (p.MimeType.startsWith("text")) {


### PR DESCRIPTION
It can't get correct file name of attachment when receive mms on gmail.
and not include content-disposition header of attachment when send mms from kitkat.