### PR TITLE
Set configuration of SmsManager.MMS_CONFIG_MAX_MESSAGE_SIZE when call SmsManager.sendMultimediaMessage()

### DIFF
--- a/library/src/main/java/com/klinker/android/send_message/Transaction.java
+++ b/library/src/main/java/com/klinker/android/send_message/Transaction.java
@@ -599,6 +599,7 @@ public class Transaction {
             if (!TextUtils.isEmpty(httpParams)) {
                 configOverrides.putString(SmsManager.MMS_CONFIG_HTTP_PARAMS, httpParams);
             }
+            configOverrides.putInt(SmsManager.MMS_CONFIG_MAX_MESSAGE_SIZE, MmsConfig.getMaxMessageSize());
 
             if (contentUri != null) {
                 SmsManager.getDefault().sendMultimediaMessage(context,


### PR DESCRIPTION
Set configuration of SmsManager.MMS_CONFIG_MAX_MESSAGE_SIZE in order to send large message.