### PR TITLE
Enable to ensure route to network in Lollipop and higher device

### DIFF
--- a/library/src/main/java/com/android/mms/service_alt/MmsNetworkManager.java
+++ b/library/src/main/java/com/android/mms/service_alt/MmsNetworkManager.java
@@ -115,13 +115,13 @@ public class MmsNetworkManager implements com.squareup.okhttp.internal.Network {
      *
      * @throws MmsNetworkException if we fail to acquire it
      */
-    public void acquireNetwork() throws MmsNetworkException {
+    public Network acquireNetwork() throws MmsNetworkException {
         synchronized (this) {
             mMmsRequestCount += 1;
             if (mNetwork != null) {
                 // Already available
                 Log.d(TAG, "MmsNetworkManager: already available");
-                return;
+                return mNetwork;
             }
             Log.d(TAG, "MmsNetworkManager: start new network request");
             // Not available, so start a new request
@@ -136,7 +136,7 @@ public class MmsNetworkManager implements com.squareup.okhttp.internal.Network {
                 }
                 if (mNetwork != null || permissionError) {
                     // Success
-                    return;
+                    return mNetwork;
                 }
                 // Calculate remaining waiting time to make sure we wait the full timeout period
                 waitTime = shouldEnd - SystemClock.elapsedRealtime();

--- a/library/src/main/java/com/android/mms/transaction/Transaction.java
+++ b/library/src/main/java/com/android/mms/transaction/Transaction.java
@@ -165,8 +165,8 @@ public abstract class Transaction extends Observable {
      *         an HTTP error code(>=400) returned from the server.
      * @throws com.google.android.mms.MmsException if pdu is null.
      */
-    protected byte[] sendPdu(long token, byte[] pdu,
-            String mmscUrl) throws IOException, MmsException {
+    protected byte[] sendPdu(final long token, final byte[] pdu,
+                             final String mmscUrl) throws IOException, MmsException {
         if (pdu == null) {
             throw new MmsException();
         }
@@ -183,14 +183,18 @@ public abstract class Transaction extends Observable {
                     false, null, 0);
         }
 
-        Utils.ensureRouteToHost(mContext, mmscUrl, mTransactionSettings.getProxyAddress());
-        return HttpUtils.httpConnection(
-                mContext, token,
-                mmscUrl,
-                pdu, HttpUtils.HTTP_POST_METHOD,
-                mTransactionSettings.isProxySet(),
-                mTransactionSettings.getProxyAddress(),
-                mTransactionSettings.getProxyPort());
+        return Utils.ensureRouteToMmsNetwork(mContext, mmscUrl, mTransactionSettings.getProxyAddress(), new Utils.Task<byte[]>() {
+            @Override
+            public byte[] run() throws IOException {
+                return HttpUtils.httpConnection(
+                        mContext, token,
+                        mmscUrl,
+                        pdu, HttpUtils.HTTP_POST_METHOD,
+                        mTransactionSettings.isProxySet(),
+                        mTransactionSettings.getProxyAddress(),
+                        mTransactionSettings.getProxyPort());
+            }
+        });
     }
 
     /**
@@ -202,7 +206,7 @@ public abstract class Transaction extends Observable {
      * @throws java.io.IOException if any error occurred on network interface or
      *         an HTTP error code(>=400) returned from the server.
      */
-    protected byte[] getPdu(String url) throws IOException {
+    protected byte[] getPdu(final String url) throws IOException {
         if (url == null) {
             throw new IOException("Cannot establish route: url is null");
         }
@@ -219,16 +223,20 @@ public abstract class Transaction extends Observable {
                     0);
         }
 
-        Utils.ensureRouteToHost(mContext, url, mTransactionSettings.getProxyAddress());
-        return HttpUtils.httpConnection(
-                mContext,
-                SendingProgressTokenManager.NO_TOKEN,
-                url,
-                null,
-                HttpUtils.HTTP_GET_METHOD,
-                mTransactionSettings.isProxySet(),
-                mTransactionSettings.getProxyAddress(),
-                mTransactionSettings.getProxyPort());
+        return Utils.ensureRouteToMmsNetwork(mContext, url, mTransactionSettings.getProxyAddress(), new Utils.Task<byte[]>() {
+            @Override
+            public byte[] run() throws IOException {
+                return HttpUtils.httpConnection(
+                        mContext,
+                        SendingProgressTokenManager.NO_TOKEN,
+                        url,
+                        null,
+                        HttpUtils.HTTP_GET_METHOD,
+                        mTransactionSettings.isProxySet(),
+                        mTransactionSettings.getProxyAddress(),
+                        mTransactionSettings.getProxyPort());
+            }
+        });
     }
 
     public static boolean useWifi(Context context) {

--- a/library/src/main/java/com/klinker/android/send_message/MmsReceivedService.java
+++ b/library/src/main/java/com/klinker/android/send_message/MmsReceivedService.java
@@ -172,8 +172,8 @@ public class MmsReceivedService extends IntentService {
          *         an HTTP error code(>=400) returned from the server.
          * @throws com.google.android.mms.MmsException if pdu is null.
          */
-        private byte[] sendPdu(long token, byte[] pdu,
-                               String mmscUrl) throws IOException, MmsException {
+        private byte[] sendPdu(final long token, final byte[] pdu,
+                               final String mmscUrl) throws IOException, MmsException {
             if (pdu == null) {
                 throw new MmsException();
             }
@@ -190,14 +190,18 @@ public class MmsReceivedService extends IntentService {
                         false, null, 0);
             }
 
-            Utils.ensureRouteToHost(mContext, mmscUrl, mTransactionSettings.getProxyAddress());
-            return HttpUtils.httpConnection(
-                    mContext, token,
-                    mmscUrl,
-                    pdu, HttpUtils.HTTP_POST_METHOD,
-                    mTransactionSettings.isProxySet(),
-                    mTransactionSettings.getProxyAddress(),
-                    mTransactionSettings.getProxyPort());
+            return Utils.ensureRouteToMmsNetwork(mContext, mmscUrl, mTransactionSettings.getProxyAddress(), new Utils.Task<byte[]>() {
+                @Override
+                public byte[] run() throws IOException {
+                    return HttpUtils.httpConnection(
+                            mContext, token,
+                            mmscUrl,
+                            pdu, HttpUtils.HTTP_POST_METHOD,
+                            mTransactionSettings.isProxySet(),
+                            mTransactionSettings.getProxyAddress(),
+                            mTransactionSettings.getProxyPort());
+                }
+            });
         }
 
         public abstract void run() throws IOException;


### PR DESCRIPTION
Since `ConnectivityManager # requestRouteToHostAddress ()` is deprecated in Lollipop, we implemented an alternative method.
